### PR TITLE
Removed workaround to serialization issue fixed in izenda version 2.4.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 ## Overview
 This a custom cache provider that utilizes the Redis cache.  
 
+:warning: The current version of this project will only work with Izenda versions 2.4.4+
+
 ## Installation
 
 1. Build the project and copy the following dlls to the bin folder of your Izenda API :


### PR DESCRIPTION
Removed the in memory dictionary and all its references that was used as a workaround for a previous serialization issue that has been fixed in Izenda Version 2.4.4. 