### PR TITLE
Upgraded Redis Cache library and added more test cases

### DIFF
--- a/Driver/Driver.csproj
+++ b/Driver/Driver.csproj
@@ -36,8 +36,8 @@
     <Reference Include="Izenda.BI.CacheProvider">
       <HintPath>..\Izenda.BI.CacheProvider.RedisCache\libs\Izenda.BI.CacheProvider.dll</HintPath>
     </Reference>
-    <Reference Include="StackExchange.Redis, Version=1.2.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\StackExchange.Redis.1.2.1\lib\net45\StackExchange.Redis.dll</HintPath>
+    <Reference Include="StackExchange.Redis, Version=1.2.6.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\StackExchange.Redis.1.2.6\lib\net45\StackExchange.Redis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -55,7 +55,9 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Izenda.BI.CacheProvider.RedisCache\Izenda.BI.CacheProvider.RedisCache.csproj">

--- a/Driver/packages.config
+++ b/Driver/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="StackExchange.Redis" version="1.2.1" targetFramework="net452" />
+  <package id="StackExchange.Redis" version="1.2.6" targetFramework="net452" />
 </packages>

--- a/Izenda.BI.CacheProvider.RedisCache.Test/Izenda.BI.CacheProvider.RedisCache.Test.csproj
+++ b/Izenda.BI.CacheProvider.RedisCache.Test/Izenda.BI.CacheProvider.RedisCache.Test.csproj
@@ -33,8 +33,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="StackExchange.Redis, Version=1.2.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\StackExchange.Redis.1.2.1\lib\net45\StackExchange.Redis.dll</HintPath>
+    <Reference Include="StackExchange.Redis, Version=1.2.6.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\StackExchange.Redis.1.2.6\lib\net45\StackExchange.Redis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -68,7 +68,9 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Izenda.BI.CacheProvider.RedisCache\Izenda.BI.CacheProvider.RedisCache.csproj">

--- a/Izenda.BI.CacheProvider.RedisCache.Test/Izenda.BI.CacheProvider.RedisCache.Test.csproj
+++ b/Izenda.BI.CacheProvider.RedisCache.Test/Izenda.BI.CacheProvider.RedisCache.Test.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\xunit.runner.visualstudio.2.3.0\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\packages\xunit.runner.visualstudio.2.3.0\build\net20\xunit.runner.visualstudio.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -11,6 +12,8 @@
     <AssemblyName>Izenda.BI.CacheProvider.RedisCache.Test</AssemblyName>
     <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -30,8 +33,13 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="StackExchange.Redis, Version=1.2.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\StackExchange.Redis.1.2.1\lib\net45\StackExchange.Redis.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.IO.Compression" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
@@ -68,7 +76,16 @@
       <Name>Izenda.BI.CacheProvider.RedisCache</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\xunit.runner.visualstudio.2.3.0\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.runner.visualstudio.2.3.0\build\net20\xunit.runner.visualstudio.props'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Izenda.BI.CacheProvider.RedisCache.Test/RedisCacheProviderTest.cs
+++ b/Izenda.BI.CacheProvider.RedisCache.Test/RedisCacheProviderTest.cs
@@ -1,4 +1,6 @@
-﻿using Xunit;
+﻿using StackExchange.Redis;
+using System;
+using Xunit;
 
 namespace Izenda.BI.CacheProvider.RedisCache.Test
 {
@@ -6,6 +8,7 @@ namespace Izenda.BI.CacheProvider.RedisCache.Test
     {
         private const string Key = "test_key";
         private const string Value = "test value";
+        private readonly ConnectionMultiplexer connection = ConnectionMultiplexer.Connect("127.0.0.1:6379,abortConnect=false");
 
         /// <summary>
         /// Test function Add()
@@ -13,11 +16,103 @@ namespace Izenda.BI.CacheProvider.RedisCache.Test
         [Fact]
         public void AddValueToCache_NoExpiration()
         {
-            var redisCacheProvider = new RedisCacheProvider();
+            var redisCacheProvider = new RedisCacheProvider(connection.GetDatabase());
             redisCacheProvider.Add(Key, Value);
             var valueFromCache = redisCacheProvider.Get<string>(Key);
 
             Assert.Equal(Value, valueFromCache);
+        }
+
+        /// <summary>
+        /// Test function AddWithExactLifeTime()
+        /// </summary>
+        [Fact]
+        public void AddWithExactLifeTime_ExpireIn20Seconds()
+        {
+            var redisCacheProvider = new RedisCacheProvider(connection.GetDatabase());
+            redisCacheProvider.AddWithExactLifetime(Key, Value, new TimeSpan(0, 0, 20));
+            var valueFromCache = redisCacheProvider.Get<string>(Key);
+
+            Assert.Equal(Value, valueFromCache);
+        }
+
+        /// <summary>
+        /// Test function AddWithSlidingLifetime()
+        /// </summary>
+        [Fact]
+        public void AddWithSlidingLifetime_ExpireAfter20Seconds()
+        {
+            var redisCacheProvider = new RedisCacheProvider(connection.GetDatabase());
+            redisCacheProvider.AddWithSlidingLifetime(Key, Value, new TimeSpan(0, 0, 20));
+            var valueFromCache = redisCacheProvider.Get<string>(Key);
+
+            Assert.Equal(Value, valueFromCache);
+        }
+
+        /// <summary>
+        /// Test function Contain()
+        /// </summary>
+        [Fact]
+        public void ContainKey_ReturnTrueAfterAddItem()
+        {
+            var redisCacheProvider = new RedisCacheProvider(connection.GetDatabase());
+            redisCacheProvider.Add(Key, Value);
+            var containKeyInCache = redisCacheProvider.Contains(Key);
+
+            Assert.True(containKeyInCache);
+        }
+
+        /// <summary>
+        /// Test function Ensure()
+        /// </summary>
+        [Fact]
+        public void EnsureCache_ReturnCorrectObject()
+        {
+            var redisCacheProvider = new RedisCacheProvider(connection.GetDatabase());
+            redisCacheProvider.Ensure(Key, () => { return Value; });
+            var valueFromCache = redisCacheProvider.Get<string>(Key);
+
+            Assert.Equal(Value, valueFromCache);
+        }
+
+        /// <summary>
+        /// Test function EnsureCacheWithExactLifeTime()
+        /// </summary>
+        [Fact]
+        public void EnsureCacheWithExactLifeTime_ReturnCorrectObject()
+        {
+            var redisCacheProvider = new RedisCacheProvider(connection.GetDatabase());
+            redisCacheProvider.EnsureWithExactLifetime(Key, new TimeSpan(0, 0, 20), () => { return Value; });
+            var valueFromCache = redisCacheProvider.Get<string>(Key);
+
+            Assert.Equal(Value, valueFromCache);
+        }
+
+        /// <summary>
+        /// Test function TestEnsureCacheWidthSlidingLifetime()
+        /// </summary>
+        [Fact]
+        public void EnsureCacheWidthSlidingLifetime_ReturnCorrectObject()
+        {
+            var redisCacheProvider = new RedisCacheProvider(connection.GetDatabase());
+            redisCacheProvider.EnsureWithSlidingLifetime(Key, new TimeSpan(0, 0, 20), () => { return Value; });
+            var valueFromCache = redisCacheProvider.Get<string>(Key);
+
+            Assert.Equal(Value, valueFromCache);
+        }
+
+        /// <summary>
+        /// Test function Remove()
+        /// </summary>
+        [Fact]
+        public void RemoveCache_ObjectIsRemoved()
+        {
+            var redisCacheProvider = new RedisCacheProvider(connection.GetDatabase());
+            redisCacheProvider.Add(Key, Value);
+            redisCacheProvider.Remove(Key);
+
+            var containCacheKey = redisCacheProvider.Contains(Key);
+            Assert.False(containCacheKey);
         }
     }
 }

--- a/Izenda.BI.CacheProvider.RedisCache.Test/packages.config
+++ b/Izenda.BI.CacheProvider.RedisCache.Test/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="StackExchange.Redis" version="1.2.1" targetFramework="net452" />
+  <package id="StackExchange.Redis" version="1.2.6" targetFramework="net452" />
   <package id="xunit" version="2.2.0" targetFramework="net452" />
   <package id="xunit.abstractions" version="2.0.1" targetFramework="net452" />
   <package id="xunit.assert" version="2.2.0" targetFramework="net452" />

--- a/Izenda.BI.CacheProvider.RedisCache.Test/packages.config
+++ b/Izenda.BI.CacheProvider.RedisCache.Test/packages.config
@@ -1,9 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="StackExchange.Redis" version="1.2.1" targetFramework="net452" />
   <package id="xunit" version="2.2.0" targetFramework="net452" />
   <package id="xunit.abstractions" version="2.0.1" targetFramework="net452" />
   <package id="xunit.assert" version="2.2.0" targetFramework="net452" />
   <package id="xunit.core" version="2.2.0" targetFramework="net452" />
   <package id="xunit.extensibility.core" version="2.2.0" targetFramework="net452" />
   <package id="xunit.extensibility.execution" version="2.2.0" targetFramework="net452" />
+  <package id="xunit.runner.visualstudio" version="2.3.0" targetFramework="net452" developmentDependency="true" />
 </packages>

--- a/Izenda.BI.CacheProvider.RedisCache/Izenda.BI.CacheProvider.RedisCache.csproj
+++ b/Izenda.BI.CacheProvider.RedisCache/Izenda.BI.CacheProvider.RedisCache.csproj
@@ -45,16 +45,16 @@
       <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="StackExchange.Redis, Version=1.2.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\StackExchange.Redis.1.2.1\lib\net45\StackExchange.Redis.dll</HintPath>
+    <Reference Include="StackExchange.Redis, Version=1.2.6.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\StackExchange.Redis.1.2.6\lib\net45\StackExchange.Redis.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="StackExchange.Redis.Extensions.Core, Version=2.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\StackExchange.Redis.Extensions.Core.2.1.0\lib\net45\StackExchange.Redis.Extensions.Core.dll</HintPath>
+    <Reference Include="StackExchange.Redis.Extensions.Core, Version=2.4.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\StackExchange.Redis.Extensions.Core.2.4.0\lib\net45\StackExchange.Redis.Extensions.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="StackExchange.Redis.Extensions.Newtonsoft, Version=2.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\StackExchange.Redis.Extensions.Newtonsoft.2.1.0\lib\net45\StackExchange.Redis.Extensions.Newtonsoft.dll</HintPath>
+    <Reference Include="StackExchange.Redis.Extensions.Newtonsoft, Version=2.3.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\StackExchange.Redis.Extensions.Newtonsoft.2.3.0\lib\net45\StackExchange.Redis.Extensions.Newtonsoft.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -83,7 +83,9 @@
     <Folder Include="libs\" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/Izenda.BI.CacheProvider.RedisCache/packages.config
+++ b/Izenda.BI.CacheProvider.RedisCache/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
-  <package id="StackExchange.Redis" version="1.2.1" targetFramework="net452" />
-  <package id="StackExchange.Redis.Extensions.Core" version="2.1.0" targetFramework="net452" />
-  <package id="StackExchange.Redis.Extensions.Newtonsoft" version="2.1.0" targetFramework="net452" />
+  <package id="StackExchange.Redis" version="1.2.6" targetFramework="net452" />
+  <package id="StackExchange.Redis.Extensions.Core" version="2.4.0" targetFramework="net452" />
+  <package id="StackExchange.Redis.Extensions.Newtonsoft" version="2.3.0" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
Upgraded the Redis Cache library from version 1.2.1 to 1.2.6 to improve performance. I also added more unit test from the Izenda Documentation.