### PR TITLE
Added asterisk to the beginning of pattern

### DIFF
--- a/Izenda.BI.CacheProvider.RedisCache/RedisCacheProvider.cs
+++ b/Izenda.BI.CacheProvider.RedisCache/RedisCacheProvider.cs
@@ -196,7 +196,7 @@ namespace Izenda.BI.CacheProvider.RedisCache
         /// <param name="pattern">The pattern. </param>
         public void RemoveKeyWithPattern(string pattern)
         {
-            var keysToRemove = _server.Keys(_cache.Database, pattern + "*").ToArray();
+            var keysToRemove = _server.Keys(_cache.Database, $"*{pattern}*").ToArray();
 
             try
             {


### PR DESCRIPTION
I added an asterisk to the beginning of the pattern in the RemoveKeyWithPattern method. This allows to check both sides of a key -> Contains(pattern) method.