### PR TITLE
Fixed deserialization issue with duplicated list

### DIFF
--- a/Izenda.BI.CacheProvider.RedisCache/RedisCacheProvider.cs
+++ b/Izenda.BI.CacheProvider.RedisCache/RedisCacheProvider.cs
@@ -52,6 +52,7 @@ namespace Izenda.BI.CacheProvider.RedisCache
             _serializerSettings.ReferenceLoopHandling = ReferenceLoopHandling.Ignore;
             _serializerSettings.TypeNameHandling = TypeNameHandling.Objects;
             _serializerSettings.TypeNameAssemblyFormat = System.Runtime.Serialization.Formatters.FormatterAssemblyStyle.Simple;
+            _serializerSettings.ObjectCreationHandling = ObjectCreationHandling.Replace;
 
             _serializerSettings.Converters.Add(new DBServerTypeSupportingConverter());
             _serializerSettings.ContractResolver = resolver;


### PR DESCRIPTION
There was a deserialization issue where the data in list was being duplicated. I have updated the JsonSerializerSettings to replace the list instead of reusing them during the Object Creation. Documentation -> https://www.newtonsoft.com/json/help/html/DeserializeObjectCreationHandling.htm